### PR TITLE
Arguments for the Parameters (-f logfile, -c timeout, -u host) do not work

### DIFF
--- a/netcheck.sh
+++ b/netcheck.sh
@@ -202,11 +202,11 @@ CLEANUP() {
 }
 
 trap CLEANUP EXIT
-while getopts "fcup:whelp-s" opt; do
+while getopts "f:c:u:p:whelp-s" opt; do
   case $opt in
     f)
       echo "Logging to custom file: $OPTARG"
-      VAR_LOGFILE=$
+      VAR_LOGFILE=$OPTARG
       VAR_CUSTOOM_LOG=true
       ;;
     c)


### PR DESCRIPTION
**Problem description**
The parameters `-f` `-c` `-u` require arguments, but the `getopts` definition did not indicate that. Therefore the `$OPTARG` variable was empty.

Additionally `VAR_LOGFILE` is not set correctly, when `-f` is used.

**Solution**
1. Updated `getops` parameter definition to indicate the arguments for the parameters mentioned above.
2. Fixed setter for `VAR_LOGFILE`.