### PR TITLE
Added --secure to the speedtest cli command to avoid 403 errors.

### DIFF
--- a/netcheck.sh
+++ b/netcheck.sh
@@ -197,7 +197,7 @@ INSTALL_SPEEDTEST() {
 }
 
 RUN_SPEEDTEST() {
-  $VAR_SCRIPTLOC/speedtest-cli.py --simple | sed 's/^/                                                 /' | tee -a $VAR_LOGFILE
+  $VAR_SCRIPTLOC/speedtest-cli.py --simple --secure | sed 's/^/                                                 /' | tee -a $VAR_LOGFILE
 }
 
 NET_CHECK() {


### PR DESCRIPTION
By default the speedtest cli python script you download attempts to make calls over HTTP and it results in 403 errors. I added the argument --secure to the call to force it to call over HTTPS.